### PR TITLE
updated to toyplot 1.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "toyplot" %}
-{% set version = "1.0.1" %}
+{% set version = "1.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e7350b7ec5af5dab5c5a74f1a820f03a8c51424144b16411fef5def087a992d4
+  sha256: f5f3905991cdd1e1a2997bcfde499325f5804ccb06681f137a55655e4bd574ef
 
 build:
   number: 0


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

+ Update from 1.0.1 to 1.0.2.
+ build-locally.py passing on my machine (M1 macOS Monterey). 
+ important because toyplot 1.0.1 is incompatible with numpy 1.22, so conda install of toyplot breaks without pinning numpy to <1.22.
+ Release is incremental and specifically fixes numpy 1.22 problem (https://github.com/sandialabs/toyplot/releases/tag/v1.0.2)

